### PR TITLE
test: fix after updating to sdk 12.1.1

### DIFF
--- a/test/simpleGaMultiSigTest.js
+++ b/test/simpleGaMultiSigTest.js
@@ -81,6 +81,7 @@ describe('SimpleGAMultiSig', () => {
     await aeSdk.createGeneralizedAccount('authorize', source, [2, [signer1Address, signer2Address, signer3Address]], { onAccount: gaAccount });
     const isGa = await aeSdk.isGA(gaKeyPair.publicKey);
     assert.equal(isGa, true);
+    gaAccount.isGa = true;
 
     // get gaContract instance
     const { contractId: contractAddress } = await aeSdk.getAccount(gaKeyPair.publicKey);


### PR DESCRIPTION
SDK@12.1.1 has a kind of breaking change (or a bug fix): before sdk was checking is memory account a ga account, now it works only for accounts that specified as ga explicitly. In the next release I'm planning to split MemoryAccount into MemoryAccount and GeneralizedAccount.

also, I like the way how it was before:
```js
    gaAccountBeforeCreation = new MemoryAccount({ keypair: gaKeyPair });
    gaAccount = new MemoryAccount({ gaId: gaKeyPair.publicKey });
```